### PR TITLE
Preserve pinned flag when loading notes

### DIFF
--- a/file_manager.py
+++ b/file_manager.py
@@ -645,15 +645,27 @@ class FileManagerApp(QtWidgets.QWidget):
                     if category not in {"idea", "todo"}:
                         category = "idea"
                     completed = bool(item.get("completed", False))
+                    pinned = bool(item.get("pinned", False))
                     normalized_notes.append(
-                        {"content": content, "timestamp": timestamp, "category": category, "completed": completed}
+                        {
+                            "content": content,
+                            "timestamp": timestamp,
+                            "category": category,
+                            "completed": completed,
+                            "pinned": pinned,
+                        }
                     )
                 elif isinstance(item, str):
                     content = item.strip()
                     if content:
                         normalized_notes.append(
-                            {"content": content, "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M"),
-                             "category": "idea", "completed": False}
+                            {
+                                "content": content,
+                                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M"),
+                                "category": "idea",
+                                "completed": False,
+                                "pinned": False,
+                            }
                         )
         data["notes"] = normalized_notes
         font_base = data.get("font_base", DEFAULT_FONT_BASE)


### PR DESCRIPTION
## Summary
- retain each note's pinned flag when normalizing persisted notes from last_state.json
- ensure string-based legacy notes default to an unpinned state during load

## Testing
- python -m py_compile file_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cee56608048333b684594d8d986b39